### PR TITLE
Updated php Dockerfile

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg62-turbo-dev \
     libpng-dev \
     libxml2-dev \
-    mysql-client \
+    default-mysql-client \
     unzip \
     git \
     locales \


### PR DESCRIPTION
"mysql-client" is not available anymore and build breaks updated to "default-mysql-client"